### PR TITLE
Push single tag

### DIFF
--- a/.github/workflows/jaeger-dockerimage.yml
+++ b/.github/workflows/jaeger-dockerimage.yml
@@ -32,7 +32,7 @@ jobs:
         elif [[ "${GITHUB_REF}" =~ refs/tags/v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             TAG="${GITHUB_REF#"refs/tags/v"}"
             tag_and_push "${TAG}"
-	    tag_and_push "latest"
+            tag_and_push "latest"
         else
           tag_and_push "${GITHUB_REF#"refs/tags/"}"
         fi

--- a/.github/workflows/jaeger-dockerimage.yml
+++ b/.github/workflows/jaeger-dockerimage.yml
@@ -32,11 +32,7 @@ jobs:
         elif [[ "${GITHUB_REF}" =~ refs/tags/v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             TAG="${GITHUB_REF#"refs/tags/v"}"
             tag_and_push "${TAG}"
-            if [[ "${TAG}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then 
-                tag_and_push "${TAG%.*}"
-                tag_and_push "${TAG%.*.*}"; 
-                tag_and_push "latest"
-            fi
+	    tag_and_push "latest"
         else
           tag_and_push "${GITHUB_REF#"refs/tags/"}"
         fi


### PR DESCRIPTION
Cutting a numbered release pushes three images to dockerhub. We just want to use one with the complete release number.

Signed-off-by: Annanay <annanayagarwal@gmail.com>