### PR TITLE
Improve C# support, set GRPC_CSHARP_VERSION=1.28.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,34 @@
-ARG ALPINE_VERSION=3.11
-ARG GO_VERSION=1.14.2
-ARG GRPC_GATEWAY_VERSION=1.14.3
-ARG GRPC_JAVA_VERSION=1.28.1
-ARG GRPC_VERSION=1.28.1
-ARG PROTOC_GEN_GO_VERSION=1.4.0
-ARG PROTOC_GEN_GOGO_VERSION=1.3.1
+ARG ALPINE_VERSION=3.10
+ARG GO_VERSION=1.13.4
+ARG GRPC_GATEWAY_VERSION=1.12.2
+ARG GRPC_JAVA_VERSION=1.26.0
+ARG GRPC_CSHARP_VERSION=1.28.1
+ARG GRPC_VERSION=1.26.0
+ARG PROTOC_GEN_GO_VERSION=1.3.2
+ARG PROTOC_GEN_GOGO_VERSION=ba06b47c162d49f2af050fb4c75bcbc86a159d5c
 ARG PROTOC_GEN_LINT_VERSION=0.2.1
 ARG UPX_VERSION=3.96
 
 
-FROM alpine:${ALPINE_VERSION} as protoc_builder
-RUN apk add --no-cache build-base curl cmake autoconf libtool git zlib-dev linux-headers
+FROM alpine:${ALPINE_VERSION} as protoc_base
+RUN apk add --no-cache build-base curl cmake autoconf libtool git zlib-dev linux-headers && \
+    mkdir -p /out
 
-RUN mkdir -p /out
 
-
+FROM protoc_base as protoc_builder
 ARG GRPC_VERSION
-RUN git clone --recursive --depth=1 -b v${GRPC_VERSION} https://github.com/grpc/grpc.git /grpc && \
+RUN apk add --no-cache automake && \
+    git clone --recursive --depth=1 -b v${GRPC_VERSION} https://github.com/grpc/grpc.git /grpc && \
     ln -s /grpc/third_party/protobuf /protobuf && \
-    mkdir -p /grpc/cmake/build && \
-    cd /grpc/cmake/build && \
-	cmake \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DgRPC_BUILD_TESTS=OFF \
-        -DgRPC_INSTALL=ON \
-		-DCMAKE_INSTALL_PREFIX=/out/usr \
-        ../.. && \
-    make -j4 install
+    cd /protobuf && \
+    ./autogen.sh && \
+    ./configure --prefix=/usr --enable-static=no && \
+    make -j4 && \
+    make -j4 check && \
+    make -j4 install && \
+    make -j4 install DESTDIR=/out && \
+    cd /grpc && \
+    make -j4 install-plugins prefix=/out/usr
 
 ARG GRPC_JAVA_VERSION
 RUN mkdir -p /grpc-java && \
@@ -40,7 +42,26 @@ RUN mkdir -p /grpc-java && \
         -L/out/usr/lib64 \
         -lprotoc -lprotobuf -lpthread --std=c++0x -s \
         -o protoc-gen-grpc-java && \
-    install -Ds protoc-gen-grpc-java /out/usr/bin/protoc-gen-grpc-java
+    install -Ds protoc-gen-grpc-java /out/usr/bin/protoc-gen-grpc-java && \
+    rm -Rf /grpc-java && \
+    rm -Rf /grpc
+
+
+FROM protoc_base AS protoc_cs_builder
+ARG GRPC_CSHARP_VERSION
+RUN git clone --recursive --depth=1 -b v${GRPC_CSHARP_VERSION} https://github.com/grpc/grpc.git /grpc && \
+    ln -s /grpc/third_party/protobuf /protobuf && \
+    mkdir -p /grpc/cmake/build && \
+    cd /grpc/cmake/build && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DgRPC_BUILD_TESTS=OFF \
+        -DgRPC_INSTALL=ON \
+        -DCMAKE_INSTALL_PREFIX=/out/usr \
+        ../.. && \
+    make -j4 install && \
+    rm -Rf /grpc
+
 
 FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} as go_builder
 RUN apk add --no-cache build-base curl git
@@ -54,7 +75,7 @@ RUN mkdir -p ${GOPATH}/src/github.com/golang/protobuf && \
 
 ARG PROTOC_GEN_GOGO_VERSION
 RUN mkdir -p ${GOPATH}/src/github.com/gogo/protobuf && \
-    curl -sSL https://api.github.com/repos/gogo/protobuf/tarball/v${PROTOC_GEN_GOGO_VERSION} | tar xz --strip 1 -C ${GOPATH}/src/github.com/gogo/protobuf &&\
+    curl -sSL https://api.github.com/repos/gogo/protobuf/tarball/${PROTOC_GEN_GOGO_VERSION} | tar xz --strip 1 -C ${GOPATH}/src/github.com/gogo/protobuf &&\
     cd ${GOPATH}/src/github.com/gogo/protobuf && \
     go build -ldflags '-w -s' -o /gogo-protobuf-out/protoc-gen-gogo ./protoc-gen-gogo && \
     install -Ds /gogo-protobuf-out/protoc-gen-gogo /out/usr/bin/protoc-gen-gogo && \
@@ -86,7 +107,6 @@ RUN mkdir -p ${GOPATH}/src/github.com/grpc-ecosystem/grpc-gateway && \
     install -D $(find ./third_party/googleapis/google/rpc -name '*.proto') -t /out/usr/include/google/rpc
 
 
-
 FROM alpine:${ALPINE_VERSION} as packer
 RUN apk add --no-cache curl
 
@@ -94,12 +114,19 @@ ARG UPX_VERSION
 RUN mkdir -p /upx && curl -sSL https://github.com/upx/upx/releases/download/v${UPX_VERSION}/upx-${UPX_VERSION}-amd64_linux.tar.xz | tar xJ --strip 1 -C /upx && \
     install -D /upx/upx /usr/local/bin/upx
 
+# Use all output including headers and protoc from protoc_builder
 COPY --from=protoc_builder /out/ /out/
+# Use protoc and plugin from protoc_cs_builder
+COPY --from=protoc_cs_builder /out/usr/bin/protoc-3.11.2.0 /out/usr/bin/protoc-csharp
+COPY --from=protoc_cs_builder /out/usr/bin/grpc_csharp_plugin /out/usr/bin/grpc_csharp_plugin
+# Integrate all output from go_builder
 COPY --from=go_builder /out/ /out/
+
 RUN upx --lzma \
         /out/usr/bin/grpc_* \
         /out/usr/bin/protoc-gen-*
 RUN find /out -name "*.a" -delete -or -name "*.la" -delete
+
 
 FROM alpine:${ALPINE_VERSION}
 LABEL maintainer="The Jaeger Authors"

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,12 @@ RUN git clone --recursive --depth=1 -b v${GRPC_CSHARP_VERSION} https://github.co
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DgRPC_BUILD_TESTS=OFF \
+        -gRPC_BUILD_GRPC_CPP_PLUGIN=OFF \
+        -gRPC_BUILD_GRPC_NODE_PLUGIN=OFF \
+        -gRPC_BUILD_GRPC_OBJECTIVE_C_PLUGIN=OFF \
+        -gRPC_BUILD_GRPC_PHP_PLUGIN=OFF \
+        -gRPC_BUILD_GRPC_PYTHON_PLUGIN=OFF \
+        -gRPC_BUILD_GRPC_RUBY_PLUGIN=OFF \
         -DgRPC_INSTALL=ON \
         -DCMAKE_INSTALL_PREFIX=/out/usr \
         ../.. && \
@@ -117,7 +123,7 @@ RUN mkdir -p /upx && curl -sSL https://github.com/upx/upx/releases/download/v${U
 # Use all output including headers and protoc from protoc_builder
 COPY --from=protoc_builder /out/ /out/
 # Use protoc and plugin from protoc_cs_builder
-COPY --from=protoc_cs_builder /out/usr/bin/protoc-3.11.2.0 /out/usr/bin/protoc-csharp
+COPY --from=protoc_cs_builder /out/usr/bin/protoc-* /out/usr/bin/protoc-csharp
 COPY --from=protoc_cs_builder /out/usr/bin/grpc_csharp_plugin /out/usr/bin/grpc_csharp_plugin
 # Integrate all output from go_builder
 COPY --from=go_builder /out/ /out/

--- a/protoc-wrapper
+++ b/protoc-wrapper
@@ -48,6 +48,6 @@ fi
 if [ ${csharp_out} ]; then
     ${protoc_csharp_cmd} || exit 1
 fi
-if [ ${outs[@]} ]; then
+if [ ${#outs[@]} -gt 0 ]; then
     exec ${protoc_cmd}
 fi

--- a/protoc-wrapper
+++ b/protoc-wrapper
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 c_out=""
+csharp_out=""
 includes=()
 outs=()
 args=()
@@ -8,6 +9,14 @@ for arg in $@; do
     case $arg in
         --c_out=*)
             c_out=${arg}
+            shift
+            ;;
+        --csharp_out=*)
+            csharp_out=${arg}
+            shift
+            ;;
+        --grpc-csharp_out=*)
+            csharp_out=${arg}
             shift
             ;;
         --*_out=*)
@@ -31,13 +40,14 @@ fi
 
 protoc_cmd="protoc ${includes[@]} ${outs[@]} ${args[@]}"
 protoc_c_cmd="protoc-c ${includes[@]} ${c_out} ${args[@]}"
+protoc_csharp_cmd="protoc-csharp ${includes[@]} ${csharp_out} ${args[@]}"
 
 if [ ${c_out} ]; then
-    if [ ${#outs[@]} -eq 0 ]; then
-        # only --c_out specified, no need to call `protoc`
-        exec ${protoc_c_cmd}
-    fi
     ${protoc_c_cmd} || exit 1
+fi
+if [ ${csharp_out} ]; then
+    ${protoc_csharp_cmd} || exit 1
+fi
+if [ ${outs[@]} ]; then
     exec ${protoc_cmd}
 fi
-exec ${protoc_cmd}


### PR DESCRIPTION
#### Summary
* Fixes #14

#### Changes
* Update versions to latest
* linux-headers is necessary as abseil is used as dependency
* Use cmake instead of make (deprecated)

#### Notes for Reviewers
We need at least 1.27.1 of gRPC to generate C# code for proto2 syntax (used in gogo.proto). We should make sure that all clients are able to use those 1.28.1 generated classes.

`gRPC 1.26.0` used `Protocol Buffers 3.8.0` and `gRPC 1.28.1` uses `Protocol Buffers 3.11.2`. So there might be some requirements to update the minimum version or Protocol Buffers in the libraries.