### PR TITLE
Fix grpc compilation issue in v0.3.0 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -151,4 +151,5 @@ RUN apk add --no-cache bash libstdc++ && \
     ln -s /usr/bin/grpc_node_plugin /usr/bin/protoc-gen-grpc-js && \
     ln -s /usr/bin/grpc_python_plugin /usr/bin/protoc-gen-grpc-python
 COPY protoc-wrapper /usr/bin/protoc-wrapper
+ENV LD_LIBRARY_PATH='/usr/lib:/usr/lib64:/usr/lib/local'
 ENTRYPOINT ["protoc-wrapper", "-I/usr/include"]


### PR DESCRIPTION
Currently the grpc services compilation fails on the following: 
```
docker run --rm -u 1000 -v "/home/ploffay/projects/jaegertracing/jaeger/idl:/home/ploffay/projects/jaegertracing/jaeger/idl" -w /home/ploffay/projects/jaegertracing/jaeger/idl jaegertracing/protobuf:0.3.0 --proto_path=/home/ploffay/projects/jaegertracing/jaeger/idl -Iproto/api_v2 -Iproto -I/usr/include/github.com/gogo/protobuf -Iopentelemetry-proto --gogo_out=plugins=grpc,Mgoogle/protobuf/descriptor.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/empty.proto=github.com/gogo/protobuf/types,Mgoogle/api/annotations.proto=github.com/gogo/googleapis/google/api,Mmodel.proto=github.com/jaegertracing/jaeger/model:/home/ploffay/projects/jaegertracing/jaeger/idl/proto-gen-go --python_out=proto-gen-python --js_out=proto-gen-js --cpp_out=proto-gen-cpp --csharp_out=base_namespace:proto-gen-csharp --grpc-java_out=proto-gen-java --grpc-python_out=proto-gen-python --grpc-js_out=proto-gen-js --grpc-cpp_out=proto-gen-cpp --grpc-csharp_out=proto-gen-csharp \
	proto/api_v2/query.proto \
	proto/api_v2/collector.proto \
	proto/api_v2/sampling.proto
Error loading shared library libprotoc.so.3.14.0.0: No such file or directory (needed by /usr/bin/protoc-gen-grpc-java)
Error loading shared library libprotobuf.so.3.14.0.0: No such file or directory (needed by /usr/bin/protoc-gen-grpc-java)
Error relocating /usr/bin/protoc-gen-grpc-java: _ZNK6google8protobuf16MethodDescriptor17GetSourceLocationEPNS0_14SourceLocationE: symbol not found
Error relocating /usr/bin/protoc-gen-grpc-java: _ZN6google8protobuf8compiler4java9ClassNameB5cxx11EPKNS0_14FileDescriptorE: symbol not found
Error relocating /usr/bin/protoc-gen-grpc-java: _ZNK6google8protobuf17ServiceDescriptor17GetSourceLocationEPNS0_14SourceLocationE: symbol not found
Error relocating /usr/bin/protoc-gen-grpc-java: _ZN6google8protobuf8compiler4java9ClassNameB5cxx11EPKNS0_10DescriptorE: symbol not found
Error relocating /usr/bin/protoc-gen-grpc-java: _ZN6google8protobuf2io7Printer7OutdentEv: symbol not found
Error relocating /usr/bin/protoc-gen-grpc-java: _ZN6google8protobuf8compiler10PluginMainEiPPcPKNS1_13CodeGeneratorE: symbol not found
Error relocating /usr/bin/protoc-gen-grpc-java: _ZN6google8protobuf2io7PrinterC1EPNS1_20ZeroCopyOutputStreamEc: symbol not found
Error relocating /usr/bin/protoc-gen-grpc-java: _ZN6google8protobuf2io7Printer6IndentEv: symbol not found
Error relocating /usr/bin/protoc-gen-grpc-java: _ZN6google8protobuf2io7PrinterD1Ev: symbol not found
Error relocating /usr/bin/protoc-gen-grpc-java: _ZN6google8protobuf8compiler23ParseGeneratorParameterERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPSt6vectorISt4pairIS7_S7_ESaISC_EE: symbol not found
Error relocating /usr/bin/protoc-gen-grpc-java: _ZN6google8protobuf8compiler13CodeGeneratorD2Ev: symbol not found
Error relocating /usr/bin/protoc-gen-grpc-java: _ZNK6google8protobuf16MethodDescriptor11output_typeEv: symbol not found
Error relocating /usr/bin/protoc-gen-grpc-java: _ZNK6google8protobuf16MethodDescriptor10input_typeEv: symbol not found
Error relocating /usr/bin/protoc-gen-grpc-java: _ZN6google8protobuf2io7Printer5PrintERKSt3mapINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES9_St4lessIS9_ESaISt4pairIKS9_S9_EEEPKc: symbol not found
Error relocating /usr/bin/protoc-gen-grpc-java: _ZNK6google8protobuf8compiler13CodeGenerator11GenerateAllERKSt6vectorIPKNS0_14FileDescriptorESaIS6_EERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPNS1_16GeneratorContextEPSG_: symbol not found
Error relocating /usr/bin/protoc-gen-grpc-java: _ZTIN6google8protobuf8compiler13CodeGeneratorE: symbol not found
Error relocating /usr/bin/protoc-gen-grpc-java: _ZTVN6google8protobuf8compiler13CodeGeneratorE: symbol not found
--grpc-java_out: protoc-gen-grpc-java: Plugin failed with status code 127.
make: *** [Makefile:96: proto] Error 1
```


See https://github.com/open-telemetry/build-tools/blob/main/protobuf/Dockerfile#L165