### PR TITLE
Add CI workflow to validate generated Docker image

### DIFF
--- a/.github/workflows/ci-docker-image-validation.yml
+++ b/.github/workflows/ci-docker-image-validation.yml
@@ -1,12 +1,16 @@
 name: Docker Image Validation
-on:
-    push:
-        branches:
-            - master
-    pull_request:
-        branches: 
-            - master
-
+on: 
+  push:
+    tags:
+      - '**'
+    branches:
+      - master
+  pull_request:
+    paths: 
+      - .github/workflows/jaeger-dockerimage.yml
+      - Dockerfile
+      - protoc-wrapper
+      
 jobs:
     build:
         runs-on: ubuntu-latest

--- a/.github/workflows/ci-docker-image-validation.yml
+++ b/.github/workflows/ci-docker-image-validation.yml
@@ -21,6 +21,20 @@ jobs:
             repository: jaegertracting/jaeger
             path: jaeger
 
+        - name: Checkout jaeger-idl
+          uses: actions/checkout@v4
+          with:
+            repository: jaegertracting/jaeger-idl
+            path: jaeger-idl
+
         - name: Build Proto in Jaeger
           working-directory: jaeger
-          run: make proto JAEGER_DOCKER_PROTOBUF=protobuf
+          run: |
+            make init-submodules
+            make proto JAEGER_DOCKER_PROTOBUF=protobuf
+
+        - name: Build Proto in Jaeger-idl
+          working-directory: jaeger-idl
+          run: |
+            make init-submodules
+            make proto PROTOC_IMAGE=protobuf

--- a/.github/workflows/ci-docker-image-validation.yml
+++ b/.github/workflows/ci-docker-image-validation.yml
@@ -18,13 +18,13 @@ jobs:
         - name: Checkout jaeger
           uses: actions/checkout@v4
           with:
-            repository: jaegertracting/jaeger
+            repository: jaegertracing/jaeger
             path: jaeger
 
         - name: Checkout jaeger-idl
           uses: actions/checkout@v4
           with:
-            repository: jaegertracting/jaeger-idl
+            repository: jaegertracing/jaeger-idl
             path: jaeger-idl
 
         - name: Build Proto in Jaeger

--- a/.github/workflows/ci-docker-image-validation.yml
+++ b/.github/workflows/ci-docker-image-validation.yml
@@ -1,8 +1,11 @@
 name: Docker Image Validation
 on:
+    push:
+        branches:
+            - master
     pull_request:
         branches: 
-            - master
+            - ci-validation-of-docker-images
 
 jobs:
     build:

--- a/.github/workflows/ci-docker-image-validation.yml
+++ b/.github/workflows/ci-docker-image-validation.yml
@@ -5,7 +5,7 @@ on:
             - master
     pull_request:
         branches: 
-            - ci-validation-of-docker-images
+            - master
 
 jobs:
     build:

--- a/.github/workflows/ci-docker-image-validation.yml
+++ b/.github/workflows/ci-docker-image-validation.yml
@@ -13,7 +13,7 @@ jobs:
           run: docker buildx build -t protobuf .
 
         - name: Checkout jaeger
-        - uses: actions/checkout@v4
+          uses: actions/checkout@v4
           with:
             repository: jaegertracting/jaeger
             path: jaeger

--- a/.github/workflows/ci-docker-image-validation.yml
+++ b/.github/workflows/ci-docker-image-validation.yml
@@ -1,0 +1,23 @@
+name: Docker Image Validation
+on:
+    pull_request:
+        branches: 
+            - master
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+        - uses: actions/checkout@v4
+        - name: Build the Docker image
+          run: docker buildx build -t protobuf .
+
+        - name: Checkout jaeger
+        - uses: actions/checkout@v4
+          with:
+            repository: jaegertracting/jaeger
+            path: jaeger
+
+        - name: Build Proto in Jaeger
+          working-directory: jaeger
+          run: make proto JAEGER_DOCKER_PROTOBUF=protobuf

--- a/.github/workflows/ci-docker-image-validation.yml
+++ b/.github/workflows/ci-docker-image-validation.yml
@@ -36,5 +36,5 @@ jobs:
         - name: Build Proto in Jaeger-idl
           working-directory: jaeger-idl
           run: |
-            make init-submodules
+            make init-submodule
             make proto PROTOC_IMAGE=protobuf


### PR DESCRIPTION
#### Summary
- Resolves #30 

#### Changes
- added a ci workflow to validate docker image against `jaeger` and `jaeger-idl`
- this workflow runs proto build step of both repos
